### PR TITLE
Add canvas-based cursor effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Custom Cursor Effect
+
+This example demonstrates a lightweight canvas-based cursor effect inspired by the animation on [lusion.co](https://lusion.co/). It draws a trailing line that follows the mouse cursor. The effect does not rely on external libraries so it can be easily embedded in services like Tilda.
+
+## Usage
+
+Include the `cursor.js` file and the canvas element in your page. The simplest setup is provided in `index.html`:
+
+```html
+<canvas id="cursor-canvas"></canvas>
+<script src="cursor.js"></script>
+```
+
+Make sure the canvas covers the entire page and that the default cursor is hidden.
+
+You can copy the contents of `cursor.js` into a custom code block on Tilda or host the file separately and reference it with a `<script>` tag.

--- a/cursor.js
+++ b/cursor.js
@@ -1,0 +1,40 @@
+const canvas = document.getElementById('cursor-canvas');
+const ctx = canvas.getContext('2d');
+
+const resize = () => {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+};
+window.addEventListener('resize', resize);
+resize();
+
+// hide the native cursor
+document.body.style.cursor = 'none';
+
+const points = [];
+const maxPoints = 30;
+
+window.addEventListener('mousemove', (event) => {
+  points.push({ x: event.clientX, y: event.clientY });
+  if (points.length > maxPoints) points.shift();
+});
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  for (let i = 0; i < points.length - 1; i++) {
+    const p1 = points[i];
+    const p2 = points[i + 1];
+    const alpha = (i + 1) / points.length;
+    ctx.strokeStyle = `rgba(255, 255, 255, ${alpha})`;
+    ctx.lineWidth = (maxPoints - i) / 5;
+    ctx.beginPath();
+    ctx.moveTo(p1.x, p1.y);
+    ctx.lineTo(p2.x, p2.y);
+    ctx.stroke();
+  }
+
+  requestAnimationFrame(draw);
+}
+
+draw();

--- a/index.html
+++ b/index.html
@@ -2,75 +2,27 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Cursor Effect</title>
+  <title>Custom Cursor Effect</title>
   <style>
     html, body {
       margin: 0;
       padding: 0;
       overflow: hidden;
-      background: black;
+      height: 100%;
+      background: #000;
     }
-    canvas {
-      display: block;
+    #cursor-canvas {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
     }
   </style>
 </head>
 <body>
-  <canvas id="webgl-canvas"></canvas>
-
-<script type="module">
-  import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.150.1/build/three.module.js';
-  import { EffectComposer } from 'https://cdn.jsdelivr.net/npm/three@0.150.1/examples/jsm/postprocessing/EffectComposer.js';
-  import { RenderPass } from 'https://cdn.jsdelivr.net/npm/three@0.150.1/examples/jsm/postprocessing/RenderPass.js';
-  import { ShaderPass } from 'https://cdn.jsdelivr.net/npm/three@0.150.1/examples/jsm/postprocessing/ShaderPass.js';
-
-  console.log("Shader загружен!");
-  console.log("Script работает!");
-
-  const canvas = document.getElementById('webgl-canvas');
-  const renderer = new THREE.WebGLRenderer({ canvas });
-  renderer.setSize(window.innerWidth, window.innerHeight);
-
-  const scene = new THREE.Scene();
-  const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
-
-  const loader = new THREE.TextureLoader();
-  loader.load('image.png', (texture) => {
-    console.log("Картинка загружена!");
-
-    const geometry = new THREE.PlaneGeometry(2, 2);
-    const material = new THREE.ShaderMaterial({
-      uniforms: {
-        u_texture: { value: texture },
-        u_time: { value: 0 }
-      },
-      vertexShader: `void main() { gl_Position = vec4(position, 1.0); }`,
-      fragmentShader: `
-        uniform sampler2D u_texture;
-        uniform float u_time;
-        void main() {
-          vec2 uv = gl_FragCoord.xy / vec2(${window.innerWidth.toFixed(1)}, ${window.innerHeight.toFixed(1)});
-          gl_FragColor = texture2D(u_texture, uv);
-        }
-      `
-    });
-
-    const mesh = new THREE.Mesh(geometry, material);
-    scene.add(mesh);
-
-    const composer = new EffectComposer(renderer);
-    composer.addPass(new RenderPass(scene, camera));
-    composer.addPass(new ShaderPass(material));
-
-    function animate(time) {
-      material.uniforms.u_time.value = time * 0.001;
-      composer.render();
-      requestAnimationFrame(animate);
-    }
-
-    animate();
-  });
-</script>
-
+  <canvas id="cursor-canvas"></canvas>
+  <script src="cursor.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace heavy WebGL demo with a simple canvas
- implement a trailing line cursor effect in `cursor.js`
- document how to use the effect

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e8af6d59483268d205d61a991c491